### PR TITLE
feat: generate preview from url

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ Make a POST request to `/api/method/preview_generator.api.generate_preview_from_
 {
 	"url": "https://www.example.com", // The URL you want to generate a preview of
 	"wait_for": 5000, // In milliseconds, optional, default is 0
-	"headers": {} // Optional, headers to be provided when visiting the URL
+	"headers": {}, // Optional, headers to be provided when visiting the URL
+	"format": "webp" // Optional, default is "jpg"
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Preview Generator
 
-Generate previews for given HTML content.
+Generate preview images of URLs or HTML content.
 
 ## Installation
 
@@ -12,7 +12,28 @@ bench get-app $URL_OF_THIS_REPO --branch develop
 bench install-app preview_generator
 ```
 
+You might need to install Playwright for the app to work. You can do this by running the following commands:
+
+```
+source $PATH_TO_YOUR_BENCH/env/bin/activate
+playwright install
+```
+
 ## Usage
+
+### Generate Preview of a URL
+
+Make a POST request to `/api/method/preview_generator.api.generate_preview_from_url` with the following parameters:
+
+```json
+{
+	"url": "https://www.example.com", // The URL you want to generate a preview of
+	"wait_for": 5000, // In milliseconds, optional, default is 0
+	"headers": {} // Optional, headers to be provided when visiting the URL
+}
+```
+
+### Generate Preview of HTML Content
 
 Make a POST request to `/api/method/preview_generator.api.generate_preview` with the following parameters:
 

--- a/preview_generator/api.py
+++ b/preview_generator/api.py
@@ -17,3 +17,21 @@ def generate_preview(html):
 		frappe.local.response.filecontent = image
 		frappe.local.response.type = "download"
 		context.close()
+
+
+@frappe.whitelist(allow_guest=True)
+@rate_limit(limit=60, seconds=60)
+def generate_preview_from_url(url: str, wait_for: int = 0):
+	with sync_playwright() as playwright:
+		browser = playwright.chromium.launch()
+		context = browser.new_context()
+		page = context.new_page()
+		page.goto(url)
+		page.wait_for_load_state('networkidle')
+		if wait_for:
+			page.wait_for_timeout(wait_for)
+		image = page.screenshot(type='jpeg', quality=30)
+		frappe.local.response.filename = 'preview.jpg'
+		frappe.local.response.filecontent = image
+		frappe.local.response.type = "download"
+		context.close()

--- a/preview_generator/api.py
+++ b/preview_generator/api.py
@@ -10,8 +10,7 @@ from playwright.sync_api import sync_playwright
 @frappe.whitelist(allow_guest=True)
 @rate_limit(limit=60, seconds=60)
 def generate_preview(html: str, format: str = "jpg") -> None:
-	if format not in ["jpg", "webp", "jpeg"]:
-		frappe.throw("Invalid format. Supported formats are jpg, jpeg and webp")
+	validate_format(format)
 
 	with sync_playwright() as playwright:
 		browser = playwright.chromium.launch()
@@ -22,13 +21,7 @@ def generate_preview(html: str, format: str = "jpg") -> None:
 		image = page.screenshot(type='jpeg', quality=30)
 
 		if format == "webp":
-			image_stream = io.BytesIO(image)
-			img = Image.open(image_stream)
-			output_stream = io.BytesIO()
-			img.save(output_stream, format="WEBP")
-			image = output_stream.getvalue()
-			output_stream.close()
-			image_stream.close()
+			image = get_webp_image(image)
 
 		generate_image_response(image, format)
 		context.close()
@@ -36,7 +29,9 @@ def generate_preview(html: str, format: str = "jpg") -> None:
 
 @frappe.whitelist(allow_guest=True)
 @rate_limit(limit=60, seconds=60)
-def generate_preview_from_url(url: str, wait_for: int = 0, headers: dict = None) -> None:
+def generate_preview_from_url(url: str, wait_for: int = 0, headers: dict = None, format: str = "jpg") -> None:
+	validate_format(format)
+
 	with sync_playwright() as playwright:
 		browser = playwright.chromium.launch()
 		context = browser.new_context(
@@ -48,10 +43,30 @@ def generate_preview_from_url(url: str, wait_for: int = 0, headers: dict = None)
 		if wait_for:
 			page.wait_for_timeout(wait_for)
 		image = page.screenshot(type='jpeg', quality=30)
-		generate_image_response(image, "jpg")
+
+		if format == "webp":
+			image = get_webp_image(image)
+
+		generate_image_response(image, format)
 		context.close()
 
 def generate_image_response(image_content, image_format):
 	frappe.local.response.filename = f"preview.{image_format}"
 	frappe.local.response.filecontent = image_content
 	frappe.local.response.type = "download"
+
+
+def validate_format(format: str):
+	if format not in ["jpg", "webp", "jpeg"]:
+		frappe.throw("Invalid format. Supported formats are jpg, jpeg and webp")
+
+def get_webp_image(image):
+	image_stream = io.BytesIO(image)
+	img = Image.open(image_stream)
+	output_stream = io.BytesIO()
+	img.save(output_stream, format="WEBP")
+	image = output_stream.getvalue()
+	output_stream.close()
+	image_stream.close()
+
+	return image

--- a/preview_generator/api.py
+++ b/preview_generator/api.py
@@ -21,10 +21,12 @@ def generate_preview(html):
 
 @frappe.whitelist(allow_guest=True)
 @rate_limit(limit=60, seconds=60)
-def generate_preview_from_url(url: str, wait_for: int = 0):
+def generate_preview_from_url(url: str, wait_for: int = 0, headers: dict = None):
 	with sync_playwright() as playwright:
 		browser = playwright.chromium.launch()
-		context = browser.new_context()
+		context = browser.new_context(
+			extra_http_headers=headers or {}
+		)
 		page = context.new_page()
 		page.goto(url)
 		page.wait_for_load_state('networkidle')


### PR DESCRIPTION

### Generate Preview of a URL

```json
{
	"url": "https://www.example.com",
	"wait_for": 5000,
	"headers": {},
	"format": "webp"
}
```