### PR TITLE
fix: correct setuptools build-backend in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = ["setuptools", "wheel"]
-build-backend = "setuptools.backends.legacy:build"
+build-backend = "setuptools.build_meta"
 
 [project]
 name = "preview_generator"


### PR DESCRIPTION
\`setuptools.backends.legacy:build\` isn't a real module, so \`pip install -e\` fails with \`BackendUnavailable\`, breaking the Docker build introduced by #2. Use \`setuptools.build_meta\` instead.